### PR TITLE
feat: 新增对HyperOS 3.0和Android 16的支持

### DIFF
--- a/app/src/main/java/com/fankes/miui/notify/utils/factory/FunctionFactory.kt
+++ b/app/src/main/java/com/fankes/miui/notify/utils/factory/FunctionFactory.kt
@@ -178,7 +178,7 @@ inline val isNotMIOS get() = !isMIOS
 val isSupportMiSystemVersion
     get() = when {
         isMIOS -> when (miosVersion) {
-            "1.0", "1.1", "2.0" -> true
+            "1.0", "1.1", "2.0" , "3.0"-> true
             else -> false
         }
         isMIUI -> when (miuiVersion) {
@@ -200,6 +200,7 @@ inline val isNotSupportMiSystemVersion get() = !isSupportMiSystemVersion
  */
 val androidVersionCodeName
     get() = when (Build.VERSION.SDK_INT) {
+        36 -> "W"
         35 -> "V"
         34 -> "U"
         33 -> "T"


### PR DESCRIPTION
此提交通过以下方式扩展了应用程序的兼容性：

- 在`isSupportMiSystemVersion`函数中添加了对HyperOS 3.0的支持。
- 在`androidVersionCodeName`函数中添加了Android 16 (W) 的支持。