### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This project will not be adapted i18n, please stay tuned for my new projects in 
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=fankes/MIUINativeNotifyIcon&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=fankes/MIUINativeNotifyIcon&type=Date)
 
 ## 隐私政策
 


### PR DESCRIPTION
The star history chart in the README is currently broken and has stopped rendering, which means visitors can no longer see the project's stargazer trend at a glance.

This change swaps in a working source for the chart so it displays correctly again, keeping the same chart style and parameters as before.

Since the chart is a key trust signal for new visitors, I would really appreciate it if this could be merged soon.